### PR TITLE
small fix to be able to pass a string in osc file to run_external_process

### DIFF
--- a/scenario_execution_base/scenario_execution_base/actions/run_external_process.py
+++ b/scenario_execution_base/scenario_execution_base/actions/run_external_process.py
@@ -30,7 +30,7 @@ class RunExternalProcess(py_trees.behaviour.Behaviour):
 
     def __init__(self, name, command=None):
         super().__init__(name)
-        self.command = command
+        self.command = command.split(" ") if type(command) is str else command
         self.executed = False
         self.process = None
         self.log_stdout_thread = None

--- a/scenario_execution_base/scenario_execution_base/actions/run_external_process.py
+++ b/scenario_execution_base/scenario_execution_base/actions/run_external_process.py
@@ -30,7 +30,7 @@ class RunExternalProcess(py_trees.behaviour.Behaviour):
 
     def __init__(self, name, command=None):
         super().__init__(name)
-        self.command = command.split(" ") if type(command) is str else command
+        self.command = command.split(" ") if isinstance(command, str) else command
         self.executed = False
         self.process = None
         self.log_stdout_thread = None

--- a/scenario_execution_base/test/test_run_external_process.py
+++ b/scenario_execution_base/test/test_run_external_process.py
@@ -88,7 +88,6 @@ scenario test_run_external_process:
         ret = self.scenario_execution.run()
         self.assertTrue(ret)
 
-    @unittest.skip(reason="requires fix")
     def test_multi_element_command(self):
         scenario_content = """
 import osc.standard


### PR DESCRIPTION
small fix to be able to pass a string in osc file to run_external_process

<!-- For questions please refer to https://intellabs.github.io/scenario_execution/development.html#contribute, mail to scenario-execution@intel.com or ask in a comment below -->

# Issue number and link (if applicable)
Issue Number: #28 

# Objective of pull request
pass a string in osc file to run_external_process

# Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/IntelLabs/scenario_execution/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://intellabs.github.io/scenario_execution/) reviewed and added / updated if needed (for bug fixes / features)
- [x] Format and Lint checks (`make check`) pass locally
- [ ] PR applies Apache 2.0 License to all code files

# Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. -->

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe)

# What is the current behavior?
a string command as it is passed now to run_process_command can not start

# What is the new behavior?
passimg a string value to run_process_command successfully starts the process

# How to test
create osc file containing something simmilar:
serial:
  run_external_process() with:
      keep(it.command == "ros2 run x y")

# Supplemental information
<!-- Any other information that is important to this PR. -->
