### PR TITLE
Relative spawn

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -307,6 +307,34 @@ jobs:
         with:
           name: test-example-multirobot-result
           path: test_example_multirobot/test.xml
+  test-example-external-method:
+    needs: [build]
+    runs-on: intellabs-01
+    container:
+      image: ghcr.io/intellabs/scenario-execution:humble
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Restore cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          key: ${{ runner.os }}-build-${{ github.run_number }}
+          path: .
+      - name: Test Example External Method
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          source install/setup.bash
+          export -n CYCLONEDDS_URI
+          export ROS_DOMAIN_ID=2
+          scenario_batch_execution -i examples/example_external_method/ -o test_example_external_method -- ros2 launch scenario_execution_ros scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
+      - name: Upload result
+        uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
+        if: always()
+        with:
+          name: test-example-external-method-result
+          path: test_example_external_method/test.xml
   test-scenario-execution-gazebo:
     needs: [build]
     runs-on: intellabs-01
@@ -332,7 +360,7 @@ jobs:
           export ROS_DOMAIN_ID=2
           export IGN_PARTITION=${HOSTNAME}:${GITHUB_RUN_ID}
           # shellcheck disable=SC1083
-          scenario_batch_execution -i simulation/gazebo/test_scenario_execution_gazebo/scenarios/ -o test_scenario_execution_gazebo -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR} live_tree:=True
+          scenario_batch_execution -i simulation/gazebo/test_scenario_execution_gazebo/scenarios/ -o test_scenario_execution_gazebo -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
       - name: Upload result
         uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
         if: always()
@@ -340,7 +368,18 @@ jobs:
           name: test-example-simulation-result
           path: test_example_simulation/test.xml
   tests:
-    needs: [test-scenario-execution, test-scenario-execution-ros, scenario-files-validation, test-example-scenario, test-example-library, test-example-variation, test-example-nav2, test-example-simulation, test-example-multirobot, test-scenario-execution-gazebo]
+    needs: 
+    - test-scenario-execution
+    - test-scenario-execution-ros
+    - scenario-files-validation
+    - test-example-scenario
+    - test-example-library
+    - test-example-variation
+    - test-example-nav2
+    - test-example-simulation
+    - test-example-multirobot
+    - test-example-external-method-result
+    - test-scenario-execution-gazebo
     runs-on: intellabs-01
     if: ${{ always() }}
     steps:
@@ -365,3 +404,4 @@ jobs:
             downloaded-artifacts/test-example-nav2-result/test.xml
             downloaded-artifacts/test-example-simulation-result/test.xml
             downloaded-artifacts/test-example-multirobot-result/test.xml
+            downloaded-artifacts/test-example-external-method-result/test.xml

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -378,7 +378,7 @@ jobs:
     - test-example-nav2
     - test-example-simulation
     - test-example-multirobot
-    - test-example-external-method-result
+    - test-example-external-method
     - test-scenario-execution-gazebo
     runs-on: intellabs-01
     if: ${{ always() }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -167,6 +167,7 @@ jobs:
           export ROS_DOMAIN_ID=119
           export IGN_PARTITION=${HOSTNAME}:${GITHUB_RUN_ID}
           sed -i 's/120s/900s/g' examples/example_simulation/scenarios/example_simulation.osc
+          sed -i 's/120s/1500s/g' examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
           # shellcheck disable=SC1083
           scenario_batch_execution -i examples/example_simulation/scenarios/ -o test_example_simulation -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
       - name: Test Example Multirobot

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -332,7 +332,7 @@ jobs:
           export ROS_DOMAIN_ID=2
           export IGN_PARTITION=${HOSTNAME}:${GITHUB_RUN_ID}
           # shellcheck disable=SC1083
-          scenario_batch_execution -i simulation/gazebo/test_scenario_execution_gazebo/scenarios/ -o test_scenario_execution_gazebo -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR} spawn:=False nav2:=False
+          scenario_batch_execution -i simulation/gazebo/test_scenario_execution_gazebo/scenarios/ -o test_scenario_execution_gazebo -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
       - name: Upload result
         uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
         if: always()

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -328,7 +328,8 @@ jobs:
           source install/setup.bash
           export -n CYCLONEDDS_URI
           export ROS_DOMAIN_ID=2
-          scenario_batch_execution -i examples/example_external_method/ -o test_example_external_method -- ros2 launch scenario_execution_ros scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
+          # shellcheck disable=SC1083
+          scenario_batch_execution -i examples/example_external_method/scenarios -o test_example_external_method -- ros2 launch scenario_execution_ros scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
       - name: Upload result
         uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
         if: always()

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -332,7 +332,7 @@ jobs:
           export ROS_DOMAIN_ID=2
           export IGN_PARTITION=${HOSTNAME}:${GITHUB_RUN_ID}
           # shellcheck disable=SC1083
-          scenario_batch_execution -i simulation/gazebo/test_scenario_execution_gazebo/scenarios/ -o test_scenario_execution_gazebo -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR}
+          scenario_batch_execution -i simulation/gazebo/test_scenario_execution_gazebo/scenarios/ -o test_scenario_execution_gazebo -- ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:={SCENARIO} output_dir:={OUTPUT_DIR} live_tree:=True
       - name: Upload result
         uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
         if: always()

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -251,6 +251,18 @@ Delete an object from the simulation.
 - ``entity_name``: Entity name within simulation
 - ``world_name: string``: Gazebo world name (default: ``default``)
 
+``osc_object.relative_spawn()``
+"""""""""""""""""""""""""""""""
+
+Spawn an actor relative to a given ``frame_id`` within simulation (at a specified ``distance`` in front of ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. 
+
+- ``frame_id``: The frame Id to spawn the actor relative to. (default: ``base_link``)
+- ``parent_frame_id``: The parent frame ID against which movement is evaluated. (default: ``map``)
+- ``distance``: distance value relative to the frame_id at which to spawn the new actor (default: 1.0)
+- ``world_name: string``: Gazebo world name (default: ``default``)
+- ``model: string``: Model definition
+- ``xacro_arguments: string``: (optional) Comma-separated list of argument key:=value pairs
+
 ``osc_object.spawn()``
 """"""""""""""""""""""
 
@@ -271,18 +283,6 @@ Spawn an actor within simulation.
     - ``https:://fuel``: Model from `fuel.gazebosim.org <https://app.gazebosim.org/>`__ (e.g. ``https://fuel.gazebosim.org/1.0/OpenRobotics/models/Beer``)
 
     If the file ending is ``.xacro`` the model is forwarded to `xacro <https://wiki.ros.org/xacro>`__ before getting spawned.
-
-``osc_object.relative_spawn()``
-"""""""""""""""""""""""""""""""
-
-Spawn an actor relative to a given ``frame_id`` within simulation (at a specified ``distance`` in front of ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. 
-
-- ``frame_id``: The frame Id to spawn the actor relative to. (default: ``base_link``)
-- ``parent_frame_id``: The parent frame ID against which movement is evaluated. (default: ``map``)
-- ``distance``: distance value relative to the frame_id at which to spawn the new actor (default: 1.0)
-- ``world_name: string``: Gazebo world name (default: ``default``)
-- ``model: string``: Model definition
-- ``xacro_arguments: string``: (optional) Comma-separated list of argument key:=value pairs
 
 ``wait_for_sim()``
 """"""""""""""""""

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -254,7 +254,7 @@ Delete an object from the simulation.
 ``osc_object.relative_spawn()``
 """""""""""""""""""""""""""""""
 
-Spawn an actor relative to a given ``frame_id`` within simulation (at a specified ``distance`` in front of ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. 
+Spawn an actor relative to a given ``frame_id`` within simulation (at a specified ``distance`` in front of ``frame_id``).
 
 - ``frame_id``: The frame Id to spawn the actor relative to. (default: ``base_link``)
 - ``parent_frame_id``: The parent frame ID against which movement is evaluated. (default: ``map``)

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -249,6 +249,21 @@ Spawn an actor within simulation by using the ``model`` and ``namespace`` of the
 
 - ``spawn_pose: pose_3d``: Pose of the spawned actor.
 - ``world_name: string``: Gazebo world name (default: ``default``)
+- ``model: string``: Model definition
+- ``xacro_arguments: string``: Comma-separated list of argument key:=value pairs
+
+``osc_object.relative_spawn()``
+""""""""""""""""""""""
+
+Spawn an actor relative to a given ``frame_id`` within simulation (at a random distance between ``offset_min`` and ``offset_max`` to ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. The randomness of the distance can be controlled via ``seed``.
+
+- ``frame_id``: The frame Id to spawn the actor relative to. (default: ``base_link``)
+- ``parent_frame_id``: The parent frame ID against which movement is evaluated. (default: ``map``)
+- ``offset_min``: Mininmal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
+- ``offset_max``: Maxinmal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
+- ``seed``: Random seed to control the randomness of the distance offset
+- ``world_name: string``: Gazebo world name (default: ``default``)
+- ``model: string``: Model definition
 - ``xacro_arguments: string``: Comma-separated list of argument key:=value pairs
 
 ``wait_for_sim()``

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -255,13 +255,11 @@ Spawn an actor within simulation by using the ``model`` and ``namespace`` of the
 ``osc_object.relative_spawn()``
 """""""""""""""""""""""""""""""
 
-Spawn an actor relative to a given ``frame_id`` within simulation (at a random distance between ``offset_min`` and ``offset_max`` to ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. The randomness of the distance can be controlled via ``seed``.
+Spawn an actor relative to a given ``frame_id`` within simulation (at a specified ``distance`` in front of ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. 
 
 - ``frame_id``: The frame Id to spawn the actor relative to. (default: ``base_link``)
 - ``parent_frame_id``: The parent frame ID against which movement is evaluated. (default: ``map``)
-- ``offset_min``: Minimal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
-- ``offset_max``: Maximal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
-- ``seed``: Random seed to control the randomness of the distance offset
+- ``distance``: distance value relative to the frame_id at which to spawn the new actor (default: 1.0)
 - ``world_name: string``: Gazebo world name (default: ``default``)
 - ``model: string``: Model definition
 - ``xacro_arguments: string``: Comma-separated list of argument key:=value pairs

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -150,8 +150,8 @@ Use nav2 to navigate to goal pose.
 
 Wait until a defined distance was traveled, based on odometry.
 
-- ``namespace: string``:  Namespace of the odometry topic
 - ``distance: length``: Traveled distance at which the action succeeds.
+- ``namespace_override: string``: if set, it's used as namespace (instead of the associated actor's namespace)
 
 ``differential_drive_robot.tf_close_to()``
 """"""""""""""""""""""""""""""""""""""""""

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -253,14 +253,14 @@ Spawn an actor within simulation by using the ``model`` and ``namespace`` of the
 - ``xacro_arguments: string``: Comma-separated list of argument key:=value pairs
 
 ``osc_object.relative_spawn()``
-""""""""""""""""""""""
+"""""""""""""""""""""""""""""""
 
 Spawn an actor relative to a given ``frame_id`` within simulation (at a random distance between ``offset_min`` and ``offset_max`` to ``frame_id``) by using the ``model`` and ``namespace`` of the associated actor. The randomness of the distance can be controlled via ``seed``.
 
 - ``frame_id``: The frame Id to spawn the actor relative to. (default: ``base_link``)
 - ``parent_frame_id``: The parent frame ID against which movement is evaluated. (default: ``map``)
-- ``offset_min``: Mininmal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
-- ``offset_max``: Maxinmal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
+- ``offset_min``: Minimal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
+- ``offset_max``: Maximal offset value relative to the frame_id at which to spawn the new actor (default: 0.0)
 - ``seed``: Random seed to control the randomness of the distance offset
 - ``world_name: string``: Gazebo world name (default: ``default``)
 - ``model: string``: Model definition

--- a/examples/example_simulation/models/box.sdf
+++ b/examples/example_simulation/models/box.sdf
@@ -19,14 +19,14 @@
       <collision name="collision">
         <geometry>
           <box>
-            <size>0.25 0.25 0.5</size>
+            <size>0.25 0.25 0.25</size>
           </box>
         </geometry>
       </collision>
       <visual name="visual">
         <geometry>
           <box>
-            <size>0.25 0.25 0.5</size>
+            <size>0.25 0.25 0.25</size>
           </box>
         </geometry>
       </visual>

--- a/examples/example_simulation/models/box.sdf
+++ b/examples/example_simulation/models/box.sdf
@@ -19,14 +19,14 @@
       <collision name="collision">
         <geometry>
           <box>
-            <size>0.25 0.25 0.25</size>
+            <size>0.25 0.25 0.5</size>
           </box>
         </geometry>
       </collision>
       <visual name="visual">
         <geometry>
           <box>
-            <size>0.25 0.25 0.25</size>
+            <size>0.25 0.25 0.5</size>
           </box>
         </geometry>
       </visual>

--- a/examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
+++ b/examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
@@ -18,6 +18,7 @@ scenario example_simulation:
                     box.relative_spawn(
                         offset_min: 0.5,
                         offset_max: 1.5,
+                        seed: 42,
                         model: 'example_simulation://models/box.sdf',
                         world_name: 'maze')
                     wait elapsed(7s)

--- a/examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
+++ b/examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
@@ -1,0 +1,32 @@
+import osc.ros
+import osc.gazebo
+
+scenario example_simulation:
+    robot: differential_drive_robot
+    box: osc_actor
+    do parallel:
+        serial:
+            robot.init_nav2(pose_3d(position_3d(x: 0.0m, y: 0.0m)))
+            parallel:
+                robot.nav_to_pose(goal_pose: pose_3d(position: position_3d(x: -4.0m), orientation: orientation_3d(yaw: 3.14rad)))
+                serial:
+                    robot.tf_close_to() with:
+                        keep(it.reference_point.x == -1.5m)
+                        keep(it.reference_point.y == 0.0m)
+                        keep(it.threshold == 0.35m)
+                        keep(it.robot_frame_id ==  'turtlebot4_base_link_gt')
+                    box.relative_spawn(
+                        offset_min: 0.5,
+                        offset_max: 1.5,
+                        model: 'example_simulation://models/box.sdf',
+                        world_name: 'maze')
+                    wait elapsed(7s)
+                    box.relative_spawn(
+                        offset_min: 0.5,
+                        offset_max: 1.5,
+                        model: 'example_simulation://models/box.sdf',
+                        world_name: 'maze')
+            emit end
+        time_out: serial:
+            wait elapsed(120s)
+            emit fail

--- a/examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
+++ b/examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
@@ -1,5 +1,6 @@
 import osc.ros
 import osc.gazebo
+import osc.helpers
 
 scenario example_simulation:
     robot: differential_drive_robot
@@ -16,15 +17,12 @@ scenario example_simulation:
                         keep(it.threshold == 0.35m)
                         keep(it.robot_frame_id ==  'turtlebot4_base_link_gt')
                     box.relative_spawn(
-                        offset_min: 0.5,
-                        offset_max: 1.5,
-                        seed: 42,
+                        distance: random.get_float(0.5, 1.5),
                         model: 'example_simulation://models/box.sdf',
                         world_name: 'maze')
                     wait elapsed(7s)
                     box.relative_spawn(
-                        offset_min: 0.5,
-                        offset_max: 1.5,
+                        distance: random.get_float(0.5, 1.5),
                         model: 'example_simulation://models/box.sdf',
                         world_name: 'maze')
             emit end

--- a/scenario_execution/scenario_execution/external_methods/random.py
+++ b/scenario_execution/scenario_execution/external_methods/random.py
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import random as rd
 
-def seed(seed: int = 0):
+def seed(seed: int = 0): # nosec W0621
     rd.seed(seed)  # nosec B311
 
 def get_float(min_val: dict, max_val: float):

--- a/scenario_execution/scenario_execution/external_methods/random.py
+++ b/scenario_execution/scenario_execution/external_methods/random.py
@@ -13,10 +13,10 @@
 # and limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-import random
+import random as rd
 
 def seed(seed: int = 0):
-    random.seed(seed)  # nosec B311
+    rd.seed(seed)  # nosec B311
 
 def get_float(min_val: dict, max_val: float):
-    return random.uniform(min_val, max_val)  # nosec B311
+    return rd.uniform(min_val, max_val)  # nosec B311

--- a/scenario_execution/scenario_execution/external_methods/random.py
+++ b/scenario_execution/scenario_execution/external_methods/random.py
@@ -15,8 +15,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import random as rd
 
-def seed(seed: int = 0): # nosec W0621
-    rd.seed(seed)  # nosec B311
+def seed(seed_value: int = 0):
+    rd.seed(seed_value)  # nosec B311
 
 def get_float(min_val: dict, max_val: float):
     return rd.uniform(min_val, max_val)  # nosec B311

--- a/scenario_execution/scenario_execution/external_methods/random.py
+++ b/scenario_execution/scenario_execution/external_methods/random.py
@@ -15,7 +15,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import random
 
-
-def get_float(min_val: dict, max_val: float, seed: int = 0):
+def seed(seed: int = 0):
     random.seed(seed)  # nosec B311
+
+def get_float(min_val: dict, max_val: float):
     return random.uniform(min_val, max_val)  # nosec B311

--- a/scenario_execution/scenario_execution/external_methods/random.py
+++ b/scenario_execution/scenario_execution/external_methods/random.py
@@ -16,5 +16,6 @@
 import random
 
 
-def get_float(min_val: dict, max_val: float):
+def get_float(min_val: dict, max_val: float, seed: int = 0):
+    random.seed(seed)  # nosec B311
     return random.uniform(min_val, max_val)  # nosec B311

--- a/scenario_execution/scenario_execution/lib_osc/helpers.osc
+++ b/scenario_execution/scenario_execution/lib_osc/helpers.osc
@@ -8,4 +8,4 @@ action run_process:
     command: string # Command to execute
 
 struct random:
-    def get_float(min_val: float, max_val: float) -> float is external scenario_execution.external_methods.random.get_float()
+    def get_float(min_val: float, max_val: float, seed: int) -> float is external scenario_execution.external_methods.random.get_float()

--- a/scenario_execution/scenario_execution/lib_osc/helpers.osc
+++ b/scenario_execution/scenario_execution/lib_osc/helpers.osc
@@ -8,4 +8,5 @@ action run_process:
     command: string # Command to execute
 
 struct random:
-    def get_float(min_val: float, max_val: float, seed: int = 0) -> float is external scenario_execution.external_methods.random.get_float()
+    def seed(seed: int = 0) is external scenario_execution.external_methods.random.seed()
+    def get_float(min_val: float, max_val: float) -> float is external scenario_execution.external_methods.random.get_float()

--- a/scenario_execution/scenario_execution/lib_osc/helpers.osc
+++ b/scenario_execution/scenario_execution/lib_osc/helpers.osc
@@ -8,5 +8,5 @@ action run_process:
     command: string # Command to execute
 
 struct random:
-    def seed(seed: int = 0) is external scenario_execution.external_methods.random.seed()
+    def seed(seed_value: int = 0) is external scenario_execution.external_methods.random.seed()
     def get_float(min_val: float, max_val: float) -> float is external scenario_execution.external_methods.random.get_float()

--- a/scenario_execution/scenario_execution/lib_osc/helpers.osc
+++ b/scenario_execution/scenario_execution/lib_osc/helpers.osc
@@ -8,4 +8,4 @@ action run_process:
     command: string # Command to execute
 
 struct random:
-    def get_float(min_val: float, max_val: float, seed: int) -> float is external scenario_execution.external_methods.random.get_float()
+    def get_float(min_val: float, max_val: float, seed: int = 0) -> float is external scenario_execution.external_methods.random.get_float()

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
@@ -14,23 +14,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess  # nosec B404
-from enum import Enum
-
-from std_msgs.msg import String
-
 import rclpy
 from math import sin, cos, atan2
-from rclpy.qos import QoSProfile, QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy
-from rclpy.logging import get_logger
-from rclpy.node import Node
 from tf2_ros import TransformException  # pylint: disable= no-name-in-module
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 from tf2_geometry_msgs import PoseStamped
-import py_trees
-from .gazebo_spawn_actor import GazeboSpawnActor, SpawnActionState
-from .utils import SpawnUtils
+from .gazebo_spawn_actor import GazeboSpawnActor
 
 
 class GazeboRelativeSpawnActor(GazeboSpawnActor):
@@ -47,7 +37,7 @@ class GazeboRelativeSpawnActor(GazeboSpawnActor):
         init
         """
         super().__init__(name, associated_actor, [], world_name, xacro_arguments, model)
-        
+
         self.frame_id = frame_id
         self.parent_frame_id = parent_frame_id
         self.distance = distance

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
@@ -56,7 +56,7 @@ class GazeboRelativeSpawnActor(RunProcess):
     """
 
     def __init__(self, name, associated_actor,
-                 frame_id: str, parent_frame_id: str,
+                 frame_id: str, parent_frame_id: str, seed: int,
                  offset_min: float, offset_max: float,
                  world_name: str, xacro_arguments: list, model: str, **kwargs):
         """
@@ -67,6 +67,7 @@ class GazeboRelativeSpawnActor(RunProcess):
         self.model_file = model
         self.frame_id = frame_id
         self.parent_frame_id = parent_frame_id
+        self.seed = seed
         self.offset_min = offset_min
         self.offset_max = offset_max
         self.world_name = world_name
@@ -201,8 +202,8 @@ class GazeboRelativeSpawnActor(RunProcess):
             rotation_angle = 2 * atan2(current_orientation.z, current_orientation.w)
 
             # Calculate new position with offset in front
-            # probably this can be done with another transform, but it doesn't work for me
-            offset = random.uniform(self.offset_min, self.offset_max)
+            random.seed(self.seed) #nosec
+            offset = random.uniform(self.offset_min, self.offset_max) #nosec
             new_x = current_position.x + offset * cos(rotation_angle)
             new_y = current_position.y + offset * sin(rotation_angle)
 

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
@@ -95,4 +95,4 @@ class GazeboRelativeSpawnActor(GazeboSpawnActor):
                 f' w: {new_pose.pose.orientation.w} x: {new_pose.pose.orientation.x} y: {new_pose.pose.orientation.y} z: {new_pose.pose.orientation.z}' \
                 ' } }'
         except TransformException as e:
-            raise ValueError(f"No transform available ({self.parent_frame_id}->{self.frame_id})")
+            raise ValueError(f"No transform available ({self.parent_frame_id}->{self.frame_id})") from e

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
@@ -14,9 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# import tf2_ros
-# import tf2_geometry_msgs
-import random
+import random # nosec B311 random is only used to create random distance offset
 import subprocess  # nosec B404
 from enum import Enum
 
@@ -202,8 +200,8 @@ class GazeboRelativeSpawnActor(RunProcess):
             rotation_angle = 2 * atan2(current_orientation.z, current_orientation.w)
 
             # Calculate new position with offset in front
-            random.seed(self.seed) #nosec
-            offset = random.uniform(self.offset_min, self.offset_max) #nosec
+            random.seed(self.seed) # nosec B311 random is only used to create random distance offset
+            offset = random.uniform(self.offset_min, self.offset_max) # nosec B311 random is only used to create random distance offset
             new_x = current_position.x + offset * cos(rotation_angle)
             new_y = current_position.y + offset * sin(rotation_angle)
 

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import random # nosec B311 random is only used to create random distance offset
 import subprocess  # nosec B404
 from enum import Enum
 
@@ -54,9 +53,9 @@ class GazeboRelativeSpawnActor(RunProcess):
     """
 
     def __init__(self, name, associated_actor,
-                 frame_id: str, parent_frame_id: str, seed: int,
-                 offset_min: float, offset_max: float,
-                 world_name: str, xacro_arguments: list, model: str, **kwargs):
+                 frame_id: str, parent_frame_id: str,
+                 distance: float, world_name: str, xacro_arguments: list,
+                 model: str, **kwargs):
         """
         init
         """
@@ -65,9 +64,7 @@ class GazeboRelativeSpawnActor(RunProcess):
         self.model_file = model
         self.frame_id = frame_id
         self.parent_frame_id = parent_frame_id
-        self.seed = seed
-        self.offset_min = offset_min
-        self.offset_max = offset_max
+        self.distance = distance
         self.world_name = world_name
         self.xacro_arguments = xacro_arguments
         self.current_state = SpawnActionState.WAITING_FOR_TOPIC
@@ -181,7 +178,7 @@ class GazeboRelativeSpawnActor(RunProcess):
     def calculate_new_pose(self):
         """
         Get position of the frame with frame_id relative to the parent_frame_id
-        and create a pose with and offset in front of it
+        and create a pose with specified distance in front of it
 
         """
         try:
@@ -199,11 +196,9 @@ class GazeboRelativeSpawnActor(RunProcess):
 
             rotation_angle = 2 * atan2(current_orientation.z, current_orientation.w)
 
-            # Calculate new position with offset in front
-            random.seed(self.seed) # nosec B311 random is only used to create random distance offset
-            offset = random.uniform(self.offset_min, self.offset_max) # nosec B311 random is only used to create random distance offset
-            new_x = current_position.x + offset * cos(rotation_angle)
-            new_y = current_position.y + offset * sin(rotation_angle)
+            # Calculate new position with distance in front
+            new_x = current_position.x + self.distance * cos(rotation_angle)
+            new_y = current_position.y + self.distance * sin(rotation_angle)
 
             # Create new pose
             new_pose = PoseStamped()

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_relative_spawn_actor.py
@@ -1,0 +1,257 @@
+# Copyright (C) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# import tf2_ros
+# import tf2_geometry_msgs
+import random
+import subprocess  # nosec B404
+from enum import Enum
+
+from std_msgs.msg import String
+
+from math import sin, cos, atan2
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy
+from rclpy.logging import get_logger
+from rclpy.node import Node
+from rclpy.time import Time as RclpyTime
+from tf2_ros import TransformException  # pylint: disable= no-name-in-module
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+from tf2_geometry_msgs import PoseStamped
+import py_trees
+from scenario_execution.actions.run_process import RunProcess
+from .utils import SpawnUtils
+
+
+class SpawnActionState(Enum):
+    """
+    States for executing a spawn-entity in gazebo
+    """
+    WAITING_FOR_TOPIC = 1
+    WAITING_FOR_POSE = 2
+    POSE_AVAILABLE = 3
+    MODEL_AVAILABLE = 4
+    WAITING_FOR_RESPONSE = 5
+    DONE = 6
+    FAILURE = 7
+
+
+class GazeboRelativeSpawnActor(RunProcess):
+    """
+    Class to spawn an entity into simulation
+
+    """
+
+    def __init__(self, name, associated_actor,
+                 base_link_offset_min: float, base_link_offset_max: float,
+                 world_name: str, xacro_arguments: list, model: str, **kwargs):
+        """
+        init
+        """
+        super().__init__(name, "")
+        self.entity_name = associated_actor["name"]
+        self.model_file = model
+        self.base_link_offset_min = base_link_offset_min
+        self.base_link_offset_max = base_link_offset_max
+        self.world_name = world_name
+        self.xacro_arguments = xacro_arguments
+        self.current_state = SpawnActionState.WAITING_FOR_TOPIC
+        self.node = None
+        self.logger = None
+        self.model_sub = None
+        self.sdf = None
+        self.utils = None
+        self._pose = None
+        self.sdf = None
+        self.tf_buffer = Buffer()
+
+    def setup(self, **kwargs):
+        """
+        Setup ROS2 node and model
+
+        """
+        try:
+            self.node: Node = kwargs['node']
+        except KeyError as e:
+            error_message = "didn't find 'node' in setup's kwargs [{}][{}]".format(
+                self.name, self.__class__.__name__)
+            raise KeyError(error_message) from e
+
+        self.logger = get_logger(self.name)
+        self.utils = SpawnUtils(logger=self.logger)
+        _ = TransformListener(self.tf_buffer, self.node)
+
+        if self.model_file.startswith('topic://'):
+            transient_local_qos = QoSProfile(
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=1)
+            topic = self.model_file.replace('topic://', '', 1)
+            self.current_state = SpawnActionState.WAITING_FOR_TOPIC
+            self.feedback_message = f"Waiting for model on topic {topic}"  # pylint: disable= attribute-defined-outside-init
+            self.model_sub = self.node.create_subscription(
+                String, topic, self.topic_callback, transient_local_qos)
+        else:
+            self.sdf = self.utils.parse_model_file(
+                self.model_file, self.entity_name, self.xacro_arguments)
+            self.current_state = SpawnActionState.WAITING_FOR_POSE
+
+    def update(self) -> py_trees.common.Status:
+        """
+        Send request
+        """
+        if self.current_state == SpawnActionState.WAITING_FOR_TOPIC:
+            return py_trees.common.Status.RUNNING
+        elif self.current_state == SpawnActionState.WAITING_FOR_POSE:
+            self.calculate_new_pose()
+            return py_trees.common.Status.RUNNING
+        elif self.current_state == SpawnActionState.POSE_AVAILABLE:
+            if self.sdf:
+                self.set_command(self.sdf)
+            else:
+                raise ValueError(f'Invalid model specified ({self.model_file})')
+            return py_trees.common.Status.RUNNING
+        else:
+            return super().update()
+
+    def on_executed(self):
+        """
+        Hook when process gets executed
+        """
+        self.current_state = SpawnActionState.WAITING_FOR_RESPONSE
+        self.feedback_message = f"Executed spawning, waiting for response..."  # pylint: disable= attribute-defined-outside-init
+
+    def shutdown(self):
+        """
+        Cleanup on shutdown
+        """
+        if self.current_state in [SpawnActionState.WAITING_FOR_TOPIC, SpawnActionState.MODEL_AVAILABLE]:
+            return
+
+        self.logger.info(f"Deleting entity '{self.entity_name}' from simulation.")
+        subprocess.run(["ign", "service", "-s", "/world/" + self.world_name + "/remove",  # pylint: disable=subprocess-run-check
+                        "--reqtype", "ignition.msgs.Entity",
+                        "--reptype", "ignition.msgs.Boolean",
+                        "--timeout", "1000", "--req", "name: \"" + self.entity_name + "\" type: MODEL"])
+
+    def on_process_finished(self, ret):
+        """
+        check result of process
+
+        return:
+            py_trees.common.Status
+        """
+        if self.current_state == SpawnActionState.WAITING_FOR_RESPONSE:
+            if ret == 0:
+                while True:
+                    try:
+                        line = self.output.popleft()
+                        line = line.lower()
+                        if 'error' in line or 'timed out' in line:
+                            self.logger.warn(line)
+                            self.feedback_message = f"Found error output while executing '{self.command}'"  # pylint: disable= attribute-defined-outside-init
+                            self.current_state = SpawnActionState.FAILURE
+                            return py_trees.common.Status.FAILURE
+                    except IndexError:
+                        break
+                self.current_state = SpawnActionState.DONE
+                return py_trees.common.Status.SUCCESS
+            else:
+                self.current_state = SpawnActionState.FAILURE
+                return py_trees.common.Status.FAILURE
+        else:
+            return py_trees.common.Status.INVALID
+
+    def calculate_new_pose(self):
+        """
+        Get position of base_link and create a pose with and offset in front of it
+
+        """
+        try:
+            now = RclpyTime()
+            trans = self.tf_buffer.lookup_transform('map', 'base_link', RclpyTime())
+
+            # Extract current position and orientation
+            current_position = trans.transform.translation
+            current_orientation = trans.transform.rotation
+
+            rotation_angle = 2 * atan2(current_orientation.z, current_orientation.w)
+
+            # Calculate new position with base_link_offset in front
+            # probably this can be done with another transform, but it doesn't work for me
+            offset = random.uniform(self.base_link_offset_min, self.base_link_offset_max)
+            new_x = current_position.x + offset * cos(rotation_angle)
+            new_y = current_position.y + offset * sin(rotation_angle)
+
+            # Create new pose
+            new_pose = PoseStamped()
+            new_pose.header.stamp = now.to_msg()
+            new_pose.header.frame_id = 'map'
+            new_pose.pose.position.x = new_x
+            new_pose.pose.position.y = new_y
+            new_pose.pose.position.z = current_position.z  # Assuming same height
+
+            # The orientation remains the same
+            new_pose.pose.orientation = current_orientation
+
+            self._pose = '{ position: {' \
+                f' x: {new_pose.pose.position.x} y: {new_pose.pose.position.y} z: {new_pose.pose.position.z}' \
+                ' } orientation: {' \
+                f' w: {new_pose.pose.orientation.w} x: {new_pose.pose.orientation.x} y: {new_pose.pose.orientation.y} z: {new_pose.pose.orientation.z}' \
+                ' } }'
+
+            # offset_pose = PoseStamped()
+            # offset_pose.header.frame_id = "base_link"
+            # offset_pose.pose.position.x = trans.transform.translation.x + self.base_link_offset
+            # offset_pose.pose.position.y = trans.transform.translation.y
+            # offset_pose.pose.orientation = trans.transform.rotation
+
+            # transformed_offset_pose = self.tf_buffer.transform(offset_pose, "map")
+
+            # self._pose = '{ position: {' \
+            #     f' x: {transformed_offset_pose.pose.position.x} y: {transformed_offset_pose.pose.position.y} z: {transformed_offset_pose.pose.position.z}' \
+            #     ' } orientation: {' \
+            #     f' w: {transformed_offset_pose.pose.orientation.w} x: {transformed_offset_pose.pose.orientation.x} y: {transformed_offset_pose.pose.orientation.y} z: {transformed_offset_pose.pose.orientation.z}' \
+            #     ' } }'
+
+            self.current_state = SpawnActionState.POSE_AVAILABLE
+
+        except TransformException as e:
+            self.logger.warn(f"Could not transform: {str(e)}")
+
+    def set_command(self, command):
+        """
+        Set execution command
+        """
+        super().set_command(["ign", "service", "-s", "/world/" + self.world_name + "/create",
+                             "--reqtype", "ignition.msgs.EntityFactory",
+                             "--reptype", "ignition.msgs.Boolean",
+                             "--timeout", "30000", "--req", "pose: " + str(self._pose) + " name: \"" + self.entity_name + "\" allow_renaming: true sdf: \"" + command + "\""])
+
+        self.logger.info(f'Command: {" ".join(self.get_command())}')
+        self.current_state = SpawnActionState.MODEL_AVAILABLE
+
+    def topic_callback(self, msg):
+        '''
+        Callback to receive model description from topic
+        '''
+
+        self.feedback_message = f"Model received from topic."  # pylint: disable= attribute-defined-outside-init
+        self.logger.info("Received robot_description.")
+        self.node.destroy_subscription(self.model_sub)
+        self.set_command(msg.data.replace("\"", "\\\"").replace("\n", ""))
+        self.current_state = SpawnActionState.WAITING_FOR_POSE

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_spawn_actor.py
@@ -76,7 +76,7 @@ class GazeboSpawnActor(RunProcess):
 
         self.logger = get_logger(self.name)
         self.utils = SpawnUtils(logger=self.logger)
-        
+
         if self.model.startswith('topic://'):
             transient_local_qos = QoSProfile(
                 durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
@@ -108,7 +108,7 @@ class GazeboSpawnActor(RunProcess):
                 self.current_state = SpawnActionState.WAITING_FOR_RESPONSE
                 return super().update()
             except ValueError as e:
-                self.feedback_message = str(e) # pylint: disable= attribute-defined-outside-init
+                self.feedback_message = str(e)  # pylint: disable= attribute-defined-outside-init
                 self.current_state = SpawnActionState.FAILURE
                 return py_trees.common.Status.FAILURE
         else:
@@ -176,13 +176,13 @@ class GazeboSpawnActor(RunProcess):
         except KeyError as e:
             raise ValueError("Could not get values") from e
         return pose
-        
+
     def set_command(self, command):
         """
         Set execution command
         """
         pose = self.get_spawn_pose()
-        
+
         super().set_command(["ign", "service", "-s", "/world/" + self.world_name + "/create",
                              "--reqtype", "ignition.msgs.EntityFactory",
                              "--reptype", "ignition.msgs.Boolean",

--- a/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_spawn_actor.py
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/actions/gazebo_spawn_actor.py
@@ -51,7 +51,7 @@ class GazeboSpawnActor(RunProcess):
         """
         super().__init__(name, "")
         self.entity_name = associated_actor["name"]
-        self.model_file = model
+        self.model = model
         self.spawn_pose = spawn_pose
         self.world_name = world_name
         self.xacro_arguments = xacro_arguments
@@ -76,26 +76,25 @@ class GazeboSpawnActor(RunProcess):
 
         self.logger = get_logger(self.name)
         self.utils = SpawnUtils(logger=self.logger)
-
-        if self.model_file.startswith('topic://'):
+        
+        if self.model.startswith('topic://'):
             transient_local_qos = QoSProfile(
                 durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
                 reliability=QoSReliabilityPolicy.RELIABLE,
                 history=QoSHistoryPolicy.KEEP_LAST,
                 depth=1)
-            topic = self.model_file.replace('topic://', '', 1)
+            topic = self.model.replace('topic://', '', 1)
             self.current_state = SpawnActionState.WAITING_FOR_TOPIC
             self.feedback_message = f"Waiting for model on topic {topic}"  # pylint: disable= attribute-defined-outside-init
             self.model_sub = self.node.create_subscription(
                 String, topic, self.topic_callback, transient_local_qos)
         else:
-            sdf = self.utils.parse_model_file(
-                self.model_file, self.entity_name, self.xacro_arguments)
+            self.sdf = self.utils.parse_model_file(
+                self.model, self.entity_name, self.xacro_arguments)
 
-            if sdf:
-                self.set_command(sdf)
-            else:
-                raise ValueError(f'Invalid model specified ({self.model_file})')
+            if not self.sdf:
+                raise ValueError(f'Invalid model specified ({self.model})')
+            self.current_state = SpawnActionState.MODEL_AVAILABLE
 
     def update(self) -> py_trees.common.Status:
         """
@@ -103,6 +102,15 @@ class GazeboSpawnActor(RunProcess):
         """
         if self.current_state == SpawnActionState.WAITING_FOR_TOPIC:
             return py_trees.common.Status.RUNNING
+        elif self.current_state == SpawnActionState.MODEL_AVAILABLE:
+            try:
+                self.set_command(self.sdf)
+                self.current_state = SpawnActionState.WAITING_FOR_RESPONSE
+                return super().update()
+            except ValueError as e:
+                self.feedback_message = str(e) # pylint: disable= attribute-defined-outside-init
+                self.current_state = SpawnActionState.FAILURE
+                return py_trees.common.Status.FAILURE
         else:
             return super().update()
 
@@ -110,7 +118,6 @@ class GazeboSpawnActor(RunProcess):
         """
         Hook when process gets executed
         """
-        self.current_state = SpawnActionState.WAITING_FOR_RESPONSE
         self.feedback_message = f"Executed spawning, waiting for response..."  # pylint: disable= attribute-defined-outside-init
 
     def shutdown(self):
@@ -154,10 +161,7 @@ class GazeboSpawnActor(RunProcess):
         else:
             return py_trees.common.Status.INVALID
 
-    def set_command(self, command):
-        """
-        Set execution command
-        """
+    def get_spawn_pose(self):
         # euler2quat() requires "zyx" convention,
         # while in YAML, we define as pitch-roll-yaw (xyz), since it's more intuitive.
         try:
@@ -171,13 +175,18 @@ class GazeboSpawnActor(RunProcess):
                 ' } }'
         except KeyError as e:
             raise ValueError("Could not get values") from e
+        return pose
+        
+    def set_command(self, command):
+        """
+        Set execution command
+        """
+        pose = self.get_spawn_pose()
+        
         super().set_command(["ign", "service", "-s", "/world/" + self.world_name + "/create",
                              "--reqtype", "ignition.msgs.EntityFactory",
                              "--reptype", "ignition.msgs.Boolean",
                              "--timeout", "30000", "--req", "pose: " + pose + " name: \"" + self.entity_name + "\" allow_renaming: false sdf: \"" + command + "\""])
-
-        self.logger.info(f'Command: {" ".join(self.get_command())}')
-        self.current_state = SpawnActionState.MODEL_AVAILABLE
 
     def topic_callback(self, msg):
         '''
@@ -188,3 +197,4 @@ class GazeboSpawnActor(RunProcess):
         self.logger.info("Received robot_description.")
         self.node.destroy_subscription(self.model_sub)
         self.set_command(msg.data.replace("\"", "\\\"").replace("\n", ""))
+        self.current_state = SpawnActionState.MODEL_AVAILABLE

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -18,12 +18,10 @@ action osc_actor.spawn:
     xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
 
 action osc_actor.relative_spawn:
-    # Spawn a simulation entity at a position relative the frame_id (at random distance between offset_min and offset_max to frame_id), uses namespace of entity
+    # Spawn a simulation entity at a position relative to the frame_id (at a specified distance in front of  frame_id), uses namespace of entity
     frame_id: string = 'base_link'            # frame_id to spawn the actor relative to
     parent_frame_id: string = "map"           # parent frame_id of the relative frame_id
-    offset_min: float = 0.0                   # min offset value relative to the frame_id at which to spawn the new actor
-    offset_max: float = 0.0                   # max offset value relative to the frame_id at which to spawn the new actor
-    seed: int                                 # seed to control the randomness of the distance in front of frame_id
+    distance: float = 0.0                     # distance value relative to the frame_id at which to spawn the new actor
     world_name: string = 'default'            # simulation world name
     model: string                             # model definition
     xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -18,11 +18,12 @@ action osc_actor.spawn:
     xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
 
 action osc_actor.relative_spawn:
-    # Spawn a simulation entity, uses namespace of entity
+    # Spawn a simulation entity at a position relative the frame_id (at random distance between offset_min and offset_max to frame_id), uses namespace of entity
     frame_id: string = 'base_link'            # frame_id to spawn the actor relative to
     parent_frame_id: string = "map"           # parent frame_id of the relative frame_id
     offset_min: float = 0.0                   # min offset value relative to the frame_id at which to spawn the new actor
     offset_max: float = 0.0                   # max offset value relative to the frame_id at which to spawn the new actor
+    seed: int                                 # seed to control the randomness of the distance in front of frame_id
     world_name: string = 'default'            # simulation world name
     model: string                             # model definition
     xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -19,8 +19,10 @@ action osc_actor.spawn:
 
 action osc_actor.relative_spawn:
     # Spawn a simulation entity, uses namespace of entity
-    base_link_offset_min: float = 0.0         # min offset value relative to base_link at which to spawn the new actor
-    base_link_offset_max: float = 0.0         # max offset value relative to base_link at which to spawn the new actor
+    frame_id: string = 'base_link'            # frame_id to spawn the actor relative to
+    parent_frame_id: string = "map"           # parent frame_id of the relative frame_id
+    offset_min: float = 0.0                   # min offset value relative to the frame_id at which to spawn the new actor
+    offset_max: float = 0.0                   # max offset value relative to the frame_id at which to spawn the new actor
     world_name: string = 'default'            # simulation world name
     model: string                             # model definition
     xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -21,7 +21,7 @@ action osc_actor.relative_spawn:
     # Spawn a simulation entity at a position relative to the frame_id (at a specified distance in front of  frame_id), uses namespace of entity
     frame_id: string = 'base_link'            # frame_id to spawn the actor relative to
     parent_frame_id: string = "map"           # parent frame_id of the relative frame_id
-    distance: float = 0.0                     # distance value relative to the frame_id at which to spawn the new actor
+    distance: float = 1.0                     # distance value relative to the frame_id at which to spawn the new actor
     world_name: string = 'default'            # simulation world name
     model: string                             # model definition
     xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -13,12 +13,12 @@ action osc_actor.delete:
 
 action osc_actor.relative_spawn:
     # Spawn a simulation entity at a position relative to the frame_id (at a specified distance in front of  frame_id)
-    frame_id: string = 'base_link'            # frame_id to spawn the actor relative to
-    parent_frame_id: string = "map"           # parent frame_id of the relative frame_id
-    distance: float = 1.0                     # distance value relative to the frame_id at which to spawn the new actor
-    world_name: string = 'default'            # simulation world name
-    model: string                             # model definition
-    xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs
+    frame_id: string = 'base_link'      # frame_id to spawn the actor relative to
+    parent_frame_id: string = "map"     # parent frame_id of the relative frame_id
+    distance: float = 1.0               # distance value relative to the frame_id at which to spawn the new actor
+    world_name: string = 'default'      # simulation world name
+    model: string                       # model definition
+    xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
 
 action osc_actor.spawn:
     # Spawn a simulation entity.

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -17,6 +17,14 @@ action osc_actor.spawn:
     model: string                       # model definition
     xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
 
+action osc_actor.relative_spawn:
+    # Spawn a simulation entity, uses namespace of entity
+    base_link_offset_min: float = 0.0         # min offset value relative to base_link at which to spawn the new actor
+    base_link_offset_max: float = 0.0         # max offset value relative to base_link at which to spawn the new actor
+    world_name: string = 'default'            # simulation world name
+    model: string                             # model definition
+    xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs
+
 action wait_for_sim:
     # Wait for simulation to become active
     world_name: string = 'default'      # simulation world name

--- a/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
+++ b/scenario_execution_gazebo/scenario_execution_gazebo/lib_osc/gazebo.osc
@@ -11,21 +11,21 @@ action osc_actor.delete:
     entity_name: string                 # name of the actor within simulation
     world_name: string = 'default'      # simulation world name
 
-action osc_actor.spawn:
-    # Spawn a simulation entity.
-    spawn_pose: pose_3d                 # position at which the object gets spawned
-    world_name: string = 'default'      # simulation world name
-    model: string                       # model definition
-    xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
-
 action osc_actor.relative_spawn:
-    # Spawn a simulation entity at a position relative to the frame_id (at a specified distance in front of  frame_id), uses namespace of entity
+    # Spawn a simulation entity at a position relative to the frame_id (at a specified distance in front of  frame_id)
     frame_id: string = 'base_link'            # frame_id to spawn the actor relative to
     parent_frame_id: string = "map"           # parent frame_id of the relative frame_id
     distance: float = 1.0                     # distance value relative to the frame_id at which to spawn the new actor
     world_name: string = 'default'            # simulation world name
     model: string                             # model definition
     xacro_arguments: string = ''              # comma-separated list of argument key:=value pairs
+
+action osc_actor.spawn:
+    # Spawn a simulation entity.
+    spawn_pose: pose_3d                 # position at which the object gets spawned
+    world_name: string = 'default'      # simulation world name
+    model: string                       # model definition
+    xacro_arguments: string = ''        # comma-separated list of argument key:=value pairs
 
 action wait_for_sim:
     # Wait for simulation to become active

--- a/scenario_execution_gazebo/setup.py
+++ b/scenario_execution_gazebo/setup.py
@@ -49,6 +49,7 @@ setup(
     entry_points={
         'scenario_execution.actions': [
             'osc_actor.spawn = scenario_execution_gazebo.actions.gazebo_spawn_actor:GazeboSpawnActor',
+            'osc_actor.relative_spawn = scenario_execution_gazebo.actions.gazebo_relative_spawn_actor:GazeboRelativeSpawnActor',
             'actor_exists = scenario_execution_gazebo.actions.gazebo_actor_exists:GazeboActorExists',
             'osc_actor.delete = scenario_execution_gazebo.actions.gazebo_delete_actor:GazeboDeleteActor',
             'wait_for_sim = scenario_execution_gazebo.actions.gazebo_wait_for_sim:GazeboWaitForSim',

--- a/scenario_execution_gazebo/setup.py
+++ b/scenario_execution_gazebo/setup.py
@@ -38,8 +38,8 @@ setup(
     include_package_data=True,
     entry_points={
         'scenario_execution.actions': [
-            'osc_actor.spawn = scenario_execution_gazebo.actions.gazebo_spawn_actor:GazeboSpawnActor',
             'osc_actor.relative_spawn = scenario_execution_gazebo.actions.gazebo_relative_spawn_actor:GazeboRelativeSpawnActor',
+            'osc_actor.spawn = scenario_execution_gazebo.actions.gazebo_spawn_actor:GazeboSpawnActor',
             'actor_exists = scenario_execution_gazebo.actions.gazebo_actor_exists:GazeboActorExists',
             'osc_actor.delete = scenario_execution_gazebo.actions.gazebo_delete_actor:GazeboDeleteActor',
             'wait_for_sim = scenario_execution_gazebo.actions.gazebo_wait_for_sim:GazeboWaitForSim',

--- a/scenario_execution_ros/scenario_execution_ros/actions/odometry_distance_traveled.py
+++ b/scenario_execution_ros/scenario_execution_ros/actions/odometry_distance_traveled.py
@@ -27,11 +27,11 @@ class OdometryDistanceTraveled(py_trees.behaviour.Behaviour):
     Class to wait for a certain covered distance, based on odometry
     """
 
-    def __init__(self, name, associated_actor, distance: float):
+    def __init__(self, name, associated_actor, distance: float, namespace_override: str):
         super().__init__(name)
         self.namespace = associated_actor["namespace"]
         self.distance_expected = distance
-        self.distance_traveled = 0.
+        self.distance_traveled = 0.0
         self.previous_x = 0
         self.previous_y = 0
         self.first_run = True
@@ -39,6 +39,8 @@ class OdometryDistanceTraveled(py_trees.behaviour.Behaviour):
         self.node = None
         self.subscriber = None
         self.callback_group = None
+        if namespace_override:
+            self.namespace = namespace_override
 
     def setup(self, **kwargs):
         """
@@ -86,7 +88,7 @@ class OdometryDistanceTraveled(py_trees.behaviour.Behaviour):
         '''
         Initialize before ticking.
         '''
-        self.distance_traveled = 0.
+        self.distance_traveled = 0.0
         self.previous_x = 0
         self.previous_y = 0
         self.first_run = True
@@ -101,8 +103,8 @@ class OdometryDistanceTraveled(py_trees.behaviour.Behaviour):
 
         self.logger.debug(f"ticking: {self.distance_traveled}")
         if self.distance_traveled >= self.distance_expected:
-            self.feedback_message = f"expected traveled distance reached: {self.distance_expected:.3}"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"expected traveled distance reached: {float(self.distance_expected):.3}"  # pylint: disable= attribute-defined-outside-init
             return Status.SUCCESS
         else:
-            self.feedback_message = f"distance traveled: {self.distance_traveled:.3} < {self.distance_expected:.3}"  # pylint: disable= attribute-defined-outside-init
+            self.feedback_message = f"distance traveled: {float(self.distance_traveled):.3} < {float(self.distance_expected):.3}"  # pylint: disable= attribute-defined-outside-init
         return Status.RUNNING

--- a/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
+++ b/scenario_execution_ros/scenario_execution_ros/lib_osc/ros.osc
@@ -94,7 +94,7 @@ action differential_drive_robot.nav_to_pose:
     monitor_progress: bool = true # if yes, the action returns after the goal is reached or on failure. If no, the action returns after request.
 
 action differential_drive_robot.odometry_distance_traveled:
-    namespace: string = ''
+    namespace_override: string = ''
     distance: length
 
 action differential_drive_robot.tf_close_to:

--- a/scenario_execution_ros/setup.py
+++ b/scenario_execution_ros/setup.py
@@ -53,8 +53,7 @@ setup(
             'check_data = scenario_execution_ros.actions.ros_topic_check_data:RosTopicCheckData',
             'service_call = scenario_execution_ros.actions.ros_service_call:RosServiceCall',
             'topic_publish = scenario_execution_ros.actions.ros_topic_publish:RosTopicPublish',
-            'odometry_distance_traveled = '
-            'scenario_execution_ros.actions.odometry_distance_traveled:OdometryDistanceTraveled',
+            'differential_drive_robot.odometry_distance_traveled = scenario_execution_ros.actions.odometry_distance_traveled:OdometryDistanceTraveled',
             'set_node_parameter = scenario_execution_ros.actions.ros_set_node_parameter:RosSetNodeParameter',
             'record_bag = scenario_execution_ros.actions.ros_bag_record:RosBagRecord',
             'wait_for_topics = scenario_execution_ros.actions.ros_topic_wait_for_topics:RosTopicWaitForTopics',

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
@@ -9,10 +9,10 @@ scenario test_relative_spawn:
         serial:
             robot.init_nav2(pose_3d(position_3d(x: 0.0m, y: 0.0m)))
             parallel:
-                robot.nav_to_pose(goal_pose: pose_3d(position: position_3d(x: -4.0m), orientation: orientation_3d(yaw: 3.14rad)))
+                robot.nav_to_pose(goal_pose: pose_3d(position: position_3d(x: -3.0m), orientation: orientation_3d(yaw: 3.14rad)))
                 serial:
                     robot.tf_close_to(
-                        reference_point: position_3d(x: -1.5m, y: 0.0m), 
+                        reference_point: position_3d(x: -0.5m, y: 0.0m),
                         threshold: 0.35m, 
                         robot_frame_id: 'turtlebot4_base_link_gt')
                     test_obstacle.relative_spawn(
@@ -21,5 +21,5 @@ scenario test_relative_spawn:
                         world_name: 'maze')
             emit end
         time_out: serial:
-            wait elapsed(120s)
+            wait elapsed(600s)
             emit fail

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
@@ -2,9 +2,9 @@ import osc.ros
 import osc.gazebo
 import osc.helpers
 
-scenario example_simulation:
+scenario test_relative_spawn:
     robot: differential_drive_robot
-    box: osc_actor
+    test_obstacle: osc_actor
     do parallel:
         serial:
             robot.init_nav2(pose_3d(position_3d(x: 0.0m, y: 0.0m)))
@@ -16,14 +16,9 @@ scenario example_simulation:
                         keep(it.reference_point.y == 0.0m)
                         keep(it.threshold == 0.35m)
                         keep(it.robot_frame_id ==  'turtlebot4_base_link_gt')
-                    box.relative_spawn(
-                        distance: random.get_float(0.5, 1.5),
-                        model: 'example_simulation://models/box.sdf',
-                        world_name: 'maze')
-                    wait elapsed(7s)
-                    box.relative_spawn(
-                        distance: random.get_float(0.5, 1.5),
-                        model: 'example_simulation://models/box.sdf',
+                    test_obstace.relative_spawn(
+                        distance: random.get_float(0.5, 1.5, 42),
+                        model: 'test_scenario_execution_gazebo://models/box.sdf')
                         world_name: 'maze')
             emit end
         time_out: serial:

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
@@ -16,7 +16,7 @@ scenario test_relative_spawn:
                         threshold: 0.35m, 
                         robot_frame_id: 'turtlebot4_base_link_gt')
                     test_obstacle.relative_spawn(
-                        distance: random.get_float(0.5, 1.5, 42),
+                        distance: 1.5m,
                         model: 'test_scenario_execution_gazebo://models/box.sdf',
                         world_name: 'maze')
             emit end

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
@@ -11,11 +11,10 @@ scenario test_relative_spawn:
             parallel:
                 robot.nav_to_pose(goal_pose: pose_3d(position: position_3d(x: -4.0m), orientation: orientation_3d(yaw: 3.14rad)))
                 serial:
-                    robot.tf_close_to() with:
-                        keep(it.reference_point.x == -1.5m)
-                        keep(it.reference_point.y == 0.0m)
-                        keep(it.threshold == 0.35m)
-                        keep(it.robot_frame_id ==  'turtlebot4_base_link_gt')
+                    robot.tf_close_to(
+                        reference_point: position_3d(x: -1.5m, y: 0.0m), 
+                        threshold: 0.35m, 
+                        robot_frame_id: 'turtlebot4_base_link_gt')
                     test_obstace.relative_spawn(
                         distance: random.get_float(0.5, 1.5, 42),
                         model: 'test_scenario_execution_gazebo://models/box.sdf')

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_relative_spawn.osc
@@ -15,9 +15,9 @@ scenario test_relative_spawn:
                         reference_point: position_3d(x: -1.5m, y: 0.0m), 
                         threshold: 0.35m, 
                         robot_frame_id: 'turtlebot4_base_link_gt')
-                    test_obstace.relative_spawn(
+                    test_obstacle.relative_spawn(
                         distance: random.get_float(0.5, 1.5, 42),
-                        model: 'test_scenario_execution_gazebo://models/box.sdf')
+                        model: 'test_scenario_execution_gazebo://models/box.sdf',
                         world_name: 'maze')
             emit end
         time_out: serial:

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_spawn_exists_delete.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_spawn_exists_delete.osc
@@ -6,7 +6,7 @@ scenario test_spawn_and_exists:
 
     do parallel:
         test_obstacle.spawn(
-            spawn_pose: pose_3d(position: position_3d(x: 1m, y: 0m, z: 1m)),
+            spawn_pose: pose_3d(position: position_3d(x: -3m, y: 0m, z: 1m)),
             world_name: 'maze',
             model: 'test_scenario_execution_gazebo://models/box.sdf')
         test_case: serial:

--- a/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_spawn_xacro_with_parameters.osc
+++ b/simulation/gazebo/test_scenario_execution_gazebo/scenarios/test_spawn_xacro_with_parameters.osc
@@ -6,7 +6,7 @@ scenario test_spawn_xacro_with_parameters:
 
     do parallel:
         test_obstacle.spawn(
-            spawn_pose: pose_3d(position: position_3d(z: 2m)),
+            spawn_pose: pose_3d(position: position_3d(x: -3m, z: 2m)),
             world_name: 'maze',
             xacro_arguments: 'box_width_length:=1 1,box_height:=4',
             model: 'test_scenario_execution_gazebo://models/box.sdf.xacro')


### PR DESCRIPTION
<!-- For questions please refer to https://intellabs.github.io/scenario_execution/development.html#contribute, mail to scenario-execution@intel.com or ask in a comment below -->
### Description
Added action for spawning an object in front of a given tf frame in gazebo, supersedes #86 

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->

### Pull request checklist
<!--  (Mark with "x") -->
- [ ] [Issue](https://github.com/IntelLabs/scenario_execution/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://intellabs.github.io/scenario_execution/) reviewed and added / updated if needed (for bug fixes / features)
- [x] Format and Lint checks (`make check`) pass locally
- [x] PR applies Apache 2.0 License to all code files

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. -->

<!--  (Mark one with "x") remove not chosen below -->

- [x] Bugfix
- [x] Feature

### Current behavior
no action to spawn an object relative to a given tf-frame

### New behavior
action created for spawning an object relative to a given tf-frame

### How to test
```
ros2 launch tb4_sim_scenario sim_nav_scenario_launch.py scenario:=examples/example_simulation/scenarios/example_simulation_relative_spawn.osc
```


