### PR TITLE
remodel python3-antlr4 dependency

### DIFF
--- a/deb_requirements.txt
+++ b/deb_requirements.txt
@@ -1,4 +1,3 @@
 python3-autopep8
 clang-format
 pylint
-python3-antlr4

--- a/scenario_execution/package.xml
+++ b/scenario_execution/package.xml
@@ -10,6 +10,7 @@
 
   <exec_depend>py_trees</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>python3-antlr4</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
With https://github.com/ros/rosdistro/pull/42280 being merged, model dependency to python3-antlr4 correctly.