### PR TITLE
action_call: fix shutdown

### DIFF
--- a/scenario_execution/scenario_execution/__init__.py
+++ b/scenario_execution/scenario_execution/__init__.py
@@ -17,7 +17,7 @@
 from . import actions
 from . import utils
 from . import model
-from scenario_execution.scenario_execution_base import ScenarioExecution
+from scenario_execution.scenario_execution_base import ScenarioExecution, ShutdownHandler
 from scenario_execution.utils.logging import BaseLogger, Logger
 
 __all__ = [
@@ -26,5 +26,6 @@ __all__ = [
     'model',
     'BaseLogger',
     "Logger",
-    'ScenarioExecution'
+    'ScenarioExecution',
+    'ShutdownHandler'
 ]

--- a/scenario_execution/scenario_execution/scenario_execution_base.py
+++ b/scenario_execution/scenario_execution/scenario_execution_base.py
@@ -29,6 +29,24 @@ from xml.sax.saxutils import escape  # nosec B406 # escape is only used on an in
 from timeit import default_timer as timer
 
 
+class ShutdownHandler:
+    _instance = None
+
+    def __init__(self):
+        self.futures = []
+
+    def get_instance():  # pylint: disable=no-method-argument
+        if ShutdownHandler._instance is None:
+            ShutdownHandler._instance = ShutdownHandler()
+        return ShutdownHandler._instance
+
+    def add_future(self, future):
+        self.futures.append(future)
+
+    def is_done(self):
+        return all(fut.done() for fut in self.futures)
+
+
 @dataclass
 class ScenarioResult:
     name: str

--- a/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
+++ b/scenario_execution_ros/scenario_execution_ros/scenario_execution_ros.py
@@ -19,7 +19,7 @@ import sys
 import rclpy  # pylint: disable=import-error
 import py_trees_ros  # pylint: disable=import-error
 from py_trees_ros_interfaces.srv import OpenSnapshotStream
-from scenario_execution import ScenarioExecution
+from scenario_execution import ScenarioExecution, ShutdownHandler
 from .logging_ros import RosLogger
 from .marker_handler import MarkerHandler
 
@@ -119,7 +119,10 @@ class ROSScenarioExecution(ScenarioExecution):
                     self.on_scenario_shutdown(False, "Aborted")
 
                 if self.shutdown_task is not None and self.shutdown_task.done():
-                    break
+                    shutdown_handler = ShutdownHandler.get_instance()
+                    if shutdown_handler.is_done():
+                        self.logger.info("Shutting down finished.")
+                        break
         except Exception as e:  # pylint: disable=broad-except
             self.on_scenario_shutdown(False, "Run failed", f"{e}")
         finally:
@@ -128,7 +131,6 @@ class ROSScenarioExecution(ScenarioExecution):
     def shutdown(self):
         self.logger.info("Shutting down...")
         self.behaviour_tree.shutdown()
-        self.logger.info("Shutting down finished.")
 
     def on_scenario_shutdown(self, result, failure_message="", failure_output=""):
         if self.shutdown_requested:


### PR DESCRIPTION
`action_call` action: In case `success_on_acceptance` is set to `true` the shutdown finishes correctly now.